### PR TITLE
Remove distutils args

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,13 +39,12 @@ def get_version():
 
 
 class BuildPyEx(build_py):
-    """ Little extension to install command; Allows --nostdownloader argument """
+    """ Little extension to install command; Allows --nofinddaemon argument """
     user_options = build_py.user_options + [
         # Note to self: use
-        # # ./setup.py build_py --nostdownloader install
+        # # ./setup.py build_py --nofinddaemon install
         # to enable this option
         #
-        ('nostdownloader', None, 'prevents installing StDownloader module; disables autoupdate capability'),
         ('nofinddaemon', None, 'prevents installing FindDaemonDialog module; always uses only default path to syncthig binary'),
     ]
 
@@ -54,7 +53,6 @@ class BuildPyEx(build_py):
 
     def initialize_options(self):
         build_py.initialize_options(self)
-        self.nostdownloader = False
         self.nofinddaemon = False
 
     @staticmethod
@@ -67,8 +65,6 @@ class BuildPyEx(build_py):
 
     def find_package_modules(self, package, package_dir):
         rv = build_py.find_package_modules(self, package, package_dir)
-        if self.nostdownloader:
-            BuildPyEx._remove_module(rv, "stdownloader")
         if self.nofinddaemon:
             BuildPyEx._remove_module(rv, "finddaemondialog")
         return rv

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 from distutils.core import setup
-from distutils.command.build_py import build_py
 from pathlib import Path
 import subprocess
 import glob
@@ -37,33 +36,6 @@ def get_version():
 
     return version
 
-
-class BuildPyEx(build_py):
-    """ Little extension to install command; Allows --nofinddaemon argument """
-    user_options = build_py.user_options + [
-        # Note to self: use
-        # # ./setup.py build_py --nofinddaemon install
-        # to enable this option
-        #
-    ]
-
-    def run(self):
-        build_py.run(self)
-
-    def initialize_options(self):
-        build_py.initialize_options(self)
-
-    @staticmethod
-    def _remove_module(modules, to_remove):
-        for i in modules:
-            if i[1] == to_remove:
-                modules.remove(i)
-                return
-
-
-    def find_package_modules(self, package, package_dir):
-        rv = build_py.find_package_modules(self, package, package_dir)
-        return rv
 
 def find_mos(parent, lst=[]):
     for f in os.listdir(parent):
@@ -119,5 +91,4 @@ if __name__ == "__main__" :
         ),
         data_files = data_files,
         scripts = [ "scripts/syncthing-gtk" ],
-        cmdclass = { 'build_py': BuildPyEx },
     )

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,6 @@ class BuildPyEx(build_py):
         # # ./setup.py build_py --nofinddaemon install
         # to enable this option
         #
-        ('nofinddaemon', None, 'prevents installing FindDaemonDialog module; always uses only default path to syncthig binary'),
     ]
 
     def run(self):
@@ -53,7 +52,6 @@ class BuildPyEx(build_py):
 
     def initialize_options(self):
         build_py.initialize_options(self)
-        self.nofinddaemon = False
 
     @staticmethod
     def _remove_module(modules, to_remove):
@@ -65,8 +63,6 @@ class BuildPyEx(build_py):
 
     def find_package_modules(self, package, package_dir):
         rv = build_py.find_package_modules(self, package, package_dir)
-        if self.nofinddaemon:
-            BuildPyEx._remove_module(rv, "finddaemondialog")
         return rv
 
 def find_mos(parent, lst=[]):

--- a/syncthing_gtk/app.py
+++ b/syncthing_gtk/app.py
@@ -29,10 +29,7 @@ from syncthing_gtk.uibuilder import UIBuilder
 from syncthing_gtk.identicon import IdentIcon
 from syncthing_gtk.infobox import InfoBox
 from syncthing_gtk.ribar import RIBar
-try:
-    from syncthing_gtk.stdownloader import StDownloader
-except ImportError:
-    StDownloader = None
+from syncthing_gtk.stdownloader import StDownloader
 
 
 from datetime import datetime
@@ -198,12 +195,11 @@ class App(Gtk.Application, TimerManager):
                 return 0
             if cl.get_options_dict().contains("home"):
                 self.home_dir_override = cl.get_options_dict().lookup_value("home").get_string()
-            if not StDownloader is None:
-                if cl.get_options_dict().contains("force-update"):
-                    self.force_update_version = \
-                        cl.get_options_dict().lookup_value("force-update").get_string()
-                    if not self.force_update_version.startswith("v"):
-                        self.force_update_version = "v%s" % (self.force_update_version,)
+            if cl.get_options_dict().contains("force-update"):
+                self.force_update_version = \
+                    cl.get_options_dict().lookup_value("force-update").get_string()
+                if not self.force_update_version.startswith("v"):
+                    self.force_update_version = "v%s" % (self.force_update_version,)
             if cl.get_options_dict().contains("add-repo"):
                 path = os.path.abspath(os.path.expanduser(
                     cl.get_options_dict().lookup_value("add-repo").get_string()))
@@ -294,10 +290,9 @@ class App(Gtk.Application, TimerManager):
         aso("remove-repo", 0, "If there is repository assigned with specified path, opens 'remove repository' dialog",
                 GLib.OptionArg.STRING)
         aso("no-status-icon", 0, "Don't show a tray status icon")
-        if not StDownloader is None:
-            aso("force-update", 0,
-                    "Force updater to download specific daemon version",
-                    GLib.OptionArg.STRING, GLib.OptionFlags.HIDDEN)
+        aso("force-update", 0,
+                "Force updater to download specific daemon version",
+                GLib.OptionArg.STRING, GLib.OptionFlags.HIDDEN)
 
     def setup_actions(self):
         def add_simple_action(name, callback):
@@ -506,9 +501,6 @@ class App(Gtk.Application, TimerManager):
         # User response is handled in App.cb_infobar_response
 
     def check_for_upgrade(self, *a):
-        if StDownloader is None:
-            # Can't, someone stole my updater module :(
-            return
         self.cancel_timer("updatecheck")
         if not self.config["st_autoupdate"]:
             # Disabled, don't even bother
@@ -728,7 +720,7 @@ class App(Gtk.Application, TimerManager):
                     else:
                         self.display_run_daemon_dialog()
             self.set_status(False)
-        elif reason == Daemon.OLD_VERSION and self.config["st_autoupdate"] and not self.process is None and not StDownloader is None:
+        elif reason == Daemon.OLD_VERSION and self.config["st_autoupdate"] and not self.process is None:
             # Daemon is too old, but autoupdater is enabled and I have control of deamon.
             # Try to update.
             from .configuration import LONG_AGO
@@ -2139,7 +2131,7 @@ class App(Gtk.Application, TimerManager):
                 self.cb_daemon_startup_failed(proc, "Daemon exits too fast")
                 return
             self.last_restart_time = time.time()
-            if not StDownloader is None and self.config["st_autoupdate"] and os.path.exists(self.config["syncthing_binary"] + ".new"):
+            if self.config["st_autoupdate"] and os.path.exists(self.config["syncthing_binary"] + ".new"):
                 # New daemon version is downloaded and ready to use.
                 # Switch to this version before restarting
                 self.swap_updated_binary()

--- a/syncthing_gtk/finddaemondialog.py
+++ b/syncthing_gtk/finddaemondialog.py
@@ -30,7 +30,7 @@ class FindDaemonDialog(EditorDialog):
               "%s below or click on <b>Download</b> "
               "button to download latest Syncthing package.") % (exe,)
         ))
-        if IS_XP or StDownloader is None:
+        if IS_XP:
             # Downloading is not offered on XP (github will not talk to it)
             # or if StDownloader module is not packaged
             self["lblMessage"].set_markup("%s\n%s" % (

--- a/syncthing_gtk/uisettingsdialog.py
+++ b/syncthing_gtk/uisettingsdialog.py
@@ -14,10 +14,7 @@ from syncthing_gtk.notifications import Notifications, HAS_DESKTOP_NOTIFY
 from syncthing_gtk.editordialog import EditorDialog
 from syncthing_gtk.tools import _ # gettext function
 from syncthing_gtk.configuration import LONG_AGO
-try:
-    from syncthing_gtk.stdownloader import StDownloader
-except ImportError:
-    StDownloader = None
+from syncthing_gtk.stdownloader import StDownloader
 import os, logging
 
 log = logging.getLogger("UISettingsDialog")
@@ -122,10 +119,6 @@ class UISettingsDialog(EditorDialog):
             else:
                 log.warning("Cannot find %s.py required to support %s", plugin, name)
         self["fmLblIntegrationStatus"].set_text("\n".join(status))
-        if StDownloader is None:
-            for name in ("vst_autoupdate", "lblAutoupdate", "lblsyncthing_binary",
-                         "lblsyncthing_binary2", "vsyncthing_binary", "btBrowse"):
-                self[name].set_visible(False)
         self.cb_data_loaded(copy)
         self.cb_check_value()
 

--- a/syncthing_gtk/wizard.py
+++ b/syncthing_gtk/wizard.py
@@ -14,10 +14,7 @@ from syncthing_gtk.configuration import Configuration
 from syncthing_gtk.tools import get_config_dir, IS_WINDOWS, is_portable
 from syncthing_gtk.tools import can_upgrade_binary, compare_version
 from syncthing_gtk.tools import _ # gettext function
-try:
-    from syncthing_gtk.stdownloader import StDownloader
-except ImportError:
-    StDownloader = None
+from syncthing_gtk.stdownloader import StDownloader
 
 import os, socket, random, string, bcrypt
 import logging, traceback, platform
@@ -267,16 +264,13 @@ class FindDaemonPage(Page):
         self.paths += [ self.parent.st_configdir ]
         if is_portable():
             self.paths += [ ".\\data" ]
-        if StDownloader is None:
-            self.binaries = ["syncthing"]
-        else:
-            suffix, trash = StDownloader.determine_platform()
-            self.binaries = ["syncthing", "syncthing%s" % (suffix,)]
-            if suffix == "x64":
-                # Allow 32bit binary on 64bit
-                self.binaries += ["syncthing.x86"]
-            if default_binary not in self.binaries:
-                self.binaries = [ default_binary ] + self.binaries
+        suffix, trash = StDownloader.determine_platform()
+        self.binaries = ["syncthing", "syncthing%s" % (suffix,)]
+        if suffix == "x64":
+            # Allow 32bit binary on 64bit
+            self.binaries += ["syncthing.x86"]
+        if default_binary not in self.binaries:
+            self.binaries = [ default_binary ] + self.binaries
         if IS_WINDOWS:
             self.paths += [ "c:/Program Files/syncthing",
                 "c:/Program Files (x86)/syncthing",
@@ -301,14 +295,6 @@ class FindDaemonPage(Page):
                 # On Windows, don't say anything and download Syncthing
                 # directly
                 self.parent.insert_and_go(DownloadSTPage())
-                return False
-            elif StDownloader is None:
-                # On Linux with updater disabled, generate and
-                # display error page
-                title = _("Syncthing daemon not found.")
-                message = _("Please, use package manager to install the Syncthing package.")
-                page = self.parent.error(self, title, message, False)
-                page.show_all()
                 return False
             else:
                 # On Linux with updater generate similar display error


### PR DESCRIPTION
There was the possibility to install syncthing-gtk without the STDownloader or FindDaemon modules. It was using a long-deprecated distutils feature, cmdclass override.

Unless someone finds a correct way to do that, i suggest we remove this possibility. The stdownloader and finddaemon can still be disabled via settings anyways.