### PR TITLE
appdata: remove URL to make the validator stop complaining

### DIFF
--- a/me.kozec.syncthingtk.appdata.xml
+++ b/me.kozec.syncthingtk.appdata.xml
@@ -50,7 +50,7 @@
     <release date="2023-03-12" version="v0.9.4.5">
       <description>
         <p>
-          This is the first version of Syncthing-GTK maintained by a new team at https://github.com/syncthing-gtk.
+          This is the first version of Syncthing-GTK maintained by a new team.
           Changes:
         </p>
         <ul>


### PR DESCRIPTION
To address #29 

 argv: b'flatpak run --env=G_DEBUG=fatal-criticals --command=appstream-util org.flatpak.Builder validate builddir/*/share/appdata/me.kozec.syncthingtk.appdata.xml'
 using PTY: False
builddir/files/share/appdata/me.kozec.syncthingtk.appdata.xml: FAILED:
• style-invalid         : <release> description should be prose and not contain hyperlinks [<p>This is the first version of Syncthing-GTK maintained by a new team at https://github.com/syncthing-gtk. Changes:</p><ul><li>Port to Python3. Python2 is not supported anymore.</li><li>Miscelaneous fixes about icons</li><li>Miscelaneous fixes about app indicators on KDE, Gnome.</li><li>Translation updates</li></ul>]
Validation of files failed
program finished with exit code 1